### PR TITLE
Report class for holding structured data from Detectors

### DIFF
--- a/bin/genderbias
+++ b/bin/genderbias
@@ -24,11 +24,11 @@ def main():
         # Otherwise, load the file
         doc = Document(args.file)
 
-    flags = []
+    reports = []
     for detector in ALL_DETECTORS:
-        flags += detector().get_flags(doc)
+        reports.append(detector().get_report(doc))
 
-    print("\n".join(str(f) for f in flags))
+    print("\n".join(str(report) for report in reports))
 
 
 

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -100,6 +100,19 @@ class Flag:
         )
 
 
+class Report:
+    """
+    A structured report with a name, optional summary (both strings) and Flags
+    as defined above. Output is provided as a string.
+    """
+
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return self._name
+
+
 class Detector:
     """
     Abstract class for a detector. Implement this to use.

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -114,10 +114,10 @@ class Report:
     def __str__(self):
         text = [self._name]
         if self._flags:
-            text += self._flags
+            text += [" " + str(flag) for flag in self._flags]
         if self._summary:
-            text.append(self._summary)
-        return "\n".join(str(item) for item in text)
+            text.append(" SUMMARY: " + self._summary)
+        return "\n".join(text)
 
     def add_flag(self, flag):
         self._flags.append(flag)

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -109,14 +109,21 @@ class Report:
     def __init__(self, name):
         self._name = name
         self._flags = []
+        self._summary = None
 
     def __str__(self):
+        text = [self._name]
         if self._flags:
-            return "\n".join(str(f) for f in [self._name]+self._flags)
-        return self._name
+            text += self._flags
+        if self._summary:
+            text.append(self._summary)
+        return "\n".join(str(item) for item in text)
 
     def add_flag(self, flag):
         self._flags.append(flag)
+
+    def set_summary(self, summary):
+        self._summary = summary
 
 
 class Detector:

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -108,9 +108,15 @@ class Report:
 
     def __init__(self, name):
         self._name = name
+        self._flags = []
 
     def __str__(self):
+        if self._flags:
+            return "\n".join(str(f) for f in [self._name]+self._flags)
         return self._name
+
+    def add_flag(self, flag):
+        self._flags.append(flag)
 
 
 class Detector:

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -115,8 +115,7 @@ class Report:
         text = [self._name]
         if self._flags:
             text += [" " + str(flag) for flag in self._flags]
-        if self._summary:
-            text.append(" SUMMARY: " + self._summary)
+        text.append(" SUMMARY: " + (self._summary if self._summary else "[None available]"))
         return "\n".join(text)
 
     def add_flag(self, flag):

--- a/genderbias/personal_life/__init__.py
+++ b/genderbias/personal_life/__init__.py
@@ -11,7 +11,7 @@ recommendation or evaluation.
 """
 
 from genderbias.document import Document
-from genderbias.detector import Detector, Flag, Issue
+from genderbias.detector import Detector, Flag, Issue, Report
 
 PERSONAL_LIFE_TERMS = [
     "child",
@@ -36,30 +36,32 @@ class PersonalLifeDetector(Detector):
 
     """
 
-    def get_flags(self, doc: 'Document'):
+    def get_report(self, doc):
         """
-        Flag the text based upon mentions of personal-life-related words.
+        Generate a report on the text based upon mentions of
+        personal-life-related words.
 
         Arguments:
             doc (Document): The document to check
 
         Returns:
-            List[Flag]
+            Report
 
         """
+        report = Report("Personal Life")
+
         token_indices = doc.words_with_indices()
-        flags = []
 
         for word, start, stop in token_indices:
             if word.lower() in PERSONAL_LIFE_TERMS:
-                flags.append(
+                report.add_flag(
                     Flag(start, stop, Issue(
                         "Personal Life",
                         "The word {word} tends to relate to personal life.".format(word=word),
                         "Try replacing with a sentiment about professional life."
                     ))
                 )
-        return flags
+        return report
 
 
 def personal_life_terms_prevalence(doc: 'Document') -> float:

--- a/tests/test_effort_detector.py
+++ b/tests/test_effort_detector.py
@@ -14,16 +14,11 @@ GOOD_DOCUMENTS = [
 
 def test_bad_documents_trip_detector():
     for doc in BAD_DOCUMENTS:
-        [
-            print(f) for f in EffortDetector().get_flags(Document(doc))
-        ]
-        assert(
-            len(EffortDetector().get_flags(Document(doc))) > 0
-        )
+        text = str(EffortDetector().get_report(Document(doc)))
+        assert len(text.split("\n")) > 2
 
 
 def test_good_documents_pass_detector():
     for doc in GOOD_DOCUMENTS:
-        assert(
-            len(EffortDetector().get_flags(Document(doc))) == 0
-        )
+        text = str(EffortDetector().get_report(Document(doc)))
+        assert len(text.split("\n")) == 2

--- a/tests/test_main_script.py
+++ b/tests/test_main_script.py
@@ -3,7 +3,8 @@ import os
 from pytest import fixture
 
 script = ["genderbias"]
-examples = ["example_letters/letterofRecM", "example_letters/letterofRecW"]
+examples = [dict(file="example_letters/letterofRecM", output_lines=6),
+            dict(file="example_letters/letterofRecW", output_lines=10)]
 
 @fixture(params = examples)
 def example(request):
@@ -19,22 +20,18 @@ def output_with_options(options, feed_in=""):
 
 
 def test_meta_ensure_examples_exist(example):
-    assert os.path.isfile(example)
+    assert os.path.isfile(example['file'])
 
 def test_script_help():
     help_text = 'usage: genderbias [-h] [--file FILE]\n\nCLI for gender-bias detection\n\noptional arguments:\n  -h, --help            show this help message and exit\n  --file FILE, -f FILE  The file to check\n'
     assert output_with_options(["-h"]) == help_text
 
 def test_script_file_flags(example, file_flag):
-    output = output_with_options([file_flag, example])
-    for line in output.split("\n"):
-        if line:
-            assert line[0] == "["
+    output = output_with_options([file_flag, example['file']])
+    assert len(output.strip().split("\n")) == example['output_lines']
 
 def test_script_input_from_stdin(example):
-    with open(example) as stream:
+    with open(example['file']) as stream:
         text = stream.read()
     output = output_with_options([], feed_in=text)
-    for line in output.split("\n"):
-        if line:
-            assert line[0] == "["
+    assert len(output.strip().split("\n")) == example['output_lines']

--- a/tests/test_personal_life.py
+++ b/tests/test_personal_life.py
@@ -13,12 +13,10 @@ GOOD_DOCUMENTS = [
 
 def test_bad_documents_trip_detector():
     for doc in BAD_DOCUMENTS:
-        assert(
-            len(PersonalLifeDetector().get_flags(Document(doc))) > 0
-        )
+        text = str(PersonalLifeDetector().get_report(Document(doc)))
+        assert len(text.split("\n")) > 2
 
 def test_good_documents_pass_detector():
     for doc in GOOD_DOCUMENTS:
-        assert(
-            len(PersonalLifeDetector().get_flags(Document(doc))) == 0
-        )
+        text = str(PersonalLifeDetector().get_report(Document(doc)))
+        assert len(text.split("\n")) == 2

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,15 @@
-from genderbias.detector import Report
+from genderbias.detector import Report, Issue, Flag
 
 report_name = "Text Analyzer"
 
 def test_report_str_no_flags():
     r = Report(report_name)
     assert str(r) == report_name
+
+f = Flag(0, 10, Issue(report_name, "A" "B"))
+
+def test_report_str_with_one_flag():
+    r = Report(report_name)
+    r.add_flag(f)
+    expected = report_name + "\n" + "[0-10]: " + report_name + ": AB"
+    assert str(r) == expected

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,7 @@
+from genderbias.detector import Report
+
+report_name = "Text Analyzer"
+
+def test_report_str_no_flags():
+    r = Report(report_name)
+    assert str(r) == report_name

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,10 +12,10 @@ f = Flag(0, 10, Issue(report_name, "A" "B"))
 def test_report_str_with_one_flag():
     r = Report(report_name)
     r.add_flag(f)
-    expected = report_name + "\n" + "[0-10]: " + report_name + ": AB"
+    expected = report_name + "\n [0-10]: " + report_name + ": AB"
     assert str(r) == expected
 
 def test_report_str_no_flags_with_summary():
     r = Report(report_name)
     r.set_summary(summary)
-    assert str(r) == report_name + "\n" + summary
+    assert str(r) == report_name + "\n" + " SUMMARY: " + summary

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -13,11 +13,12 @@ def report():
 
 
 def test_report_str_no_flags(report):
-    assert str(report) == report_name
+    assert str(report) == report_name + "\n" + " SUMMARY: " + "[None available]"
 
 def test_report_str_with_one_flag(report):
     report.add_flag(flag)
-    expected = report_name + "\n [0-10]: " + report_name + ": AB"
+    expected = (report_name + "\n [0-10]: " + report_name + ": AB" + "\n" +
+                " SUMMARY: " + "[None available]")
     assert str(report) == expected
 
 def test_report_str_no_flags_with_summary(report):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,6 +1,7 @@
 from genderbias.detector import Report, Issue, Flag
 
 report_name = "Text Analyzer"
+summary = "[summary]"
 
 def test_report_str_no_flags():
     r = Report(report_name)
@@ -13,3 +14,8 @@ def test_report_str_with_one_flag():
     r.add_flag(f)
     expected = report_name + "\n" + "[0-10]: " + report_name + ": AB"
     assert str(r) == expected
+
+def test_report_str_no_flags_with_summary():
+    r = Report(report_name)
+    r.set_summary(summary)
+    assert str(r) == report_name + "\n" + summary

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,21 +1,25 @@
 from genderbias.detector import Report, Issue, Flag
 
+from pytest import fixture
+
 report_name = "Text Analyzer"
 summary = "[summary]"
+flag = Flag(0, 10, Issue(report_name, "A" "B"))
 
-def test_report_str_no_flags():
-    r = Report(report_name)
-    assert str(r) == report_name
 
-f = Flag(0, 10, Issue(report_name, "A" "B"))
+@fixture
+def report():
+    return Report(report_name)
 
-def test_report_str_with_one_flag():
-    r = Report(report_name)
-    r.add_flag(f)
+
+def test_report_str_no_flags(report):
+    assert str(report) == report_name
+
+def test_report_str_with_one_flag(report):
+    report.add_flag(flag)
     expected = report_name + "\n [0-10]: " + report_name + ": AB"
-    assert str(r) == expected
+    assert str(report) == expected
 
-def test_report_str_no_flags_with_summary():
-    r = Report(report_name)
-    r.set_summary(summary)
-    assert str(r) == report_name + "\n" + " SUMMARY: " + summary
+def test_report_str_no_flags_with_summary(report):
+    report.set_summary(summary)
+    assert str(report) == report_name + "\n" + " SUMMARY: " + summary


### PR DESCRIPTION
This work is inspired by observing the use of "[0-0]" Issues as summaries, and repetition of categories in issues.

This PR adds a `Report` class, which is intended as a structured form for detectors to use:
* specify a name/title in the constructor
* add flags, as would be done currently, but into the `Report`
* set a summary, if one is relevant

The penultimate commit migrates the current code to use this, though *doesn't* currently remove the `get_flags` functions, rather just adding the `get_report` function with amended code; I'm happy to switch, if this is desirable.

The last commit is WIP (work in progress) since perhaps the `Issue` class tags need tweaking if we move ahead with this, and that commit is just as workaround to remove duplicated text.