### PR TITLE
Add Report.to_dict() method and apply to generate json from main script

### DIFF
--- a/bin/genderbias
+++ b/bin/genderbias
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
-
 import sys
+import json
 
 from genderbias import ALL_DETECTORS, Document
 
@@ -13,6 +13,10 @@ def main():
     parser.add_argument(
         "--file", "-f", dest="file", required=False,
         help="The file to check"
+    )
+    parser.add_argument(
+        "--json", "-j", dest="json", required=False, default=False, action='store_true',
+        help="Enable JSON output, instead of text"
     )
 
     args = parser.parse_args()
@@ -28,7 +32,11 @@ def main():
     for detector in ALL_DETECTORS:
         reports.append(detector().get_report(doc))
 
-    print("\n".join(str(report) for report in reports))
+    if not args.json:
+        print("\n".join(str(report) for report in reports))
+    else:
+        reports_data = [report.to_dict() for report in reports]
+        print(json.dumps(reports_data))
 
 
 

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -124,6 +124,10 @@ class Report:
     def set_summary(self, summary):
         self._summary = summary
 
+    def to_dict(self):
+        return dict(name=self._name,
+                    summary=self._summary if self._summary else "")
+
 
 class Detector:
     """

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -126,7 +126,11 @@ class Report:
 
     def to_dict(self):
         return dict(name=self._name,
-                    summary=self._summary if self._summary else "")
+                    summary=(self._summary if self._summary else ""),
+                    flags=[(flag.start, flag.stop, flag.issue.name,
+                            flag.issue.description, flag.issue.fix)
+                           for flag in self._flags]
+        )
 
 
 class Detector:

--- a/tests/test_main_script.py
+++ b/tests/test_main_script.py
@@ -1,5 +1,6 @@
 from subprocess import Popen, PIPE
 import os
+import json
 from pytest import fixture
 
 script = ["genderbias"]
@@ -14,6 +15,11 @@ def example(request):
 def file_flag(request):
     return request.param
 
+@fixture(params = ["--json", "-j"])
+def json_flag(request):
+    return request.param
+
+
 def output_with_options(options, feed_in=""):
     popen = Popen(script + options, stdin=PIPE, stdout=PIPE, universal_newlines=True)
     return popen.communicate(feed_in)[0]
@@ -23,8 +29,8 @@ def test_meta_ensure_examples_exist(example):
     assert os.path.isfile(example['file'])
 
 def test_script_help():
-    help_text = 'usage: genderbias [-h] [--file FILE]\n\nCLI for gender-bias detection\n\noptional arguments:\n  -h, --help            show this help message and exit\n  --file FILE, -f FILE  The file to check\n'
-    assert output_with_options(["-h"]) == help_text
+    start_help_text = 'usage: genderbias [-h]'
+    assert start_help_text in output_with_options(["-h"])
 
 def test_script_file_flags(example, file_flag):
     output = output_with_options([file_flag, example['file']])
@@ -35,3 +41,15 @@ def test_script_input_from_stdin(example):
         text = stream.read()
     output = output_with_options([], feed_in=text)
     assert len(output.strip().split("\n")) == example['output_lines']
+
+def test_script_json_output(example, file_flag, json_flag):
+    output = output_with_options([file_flag, example['file'], json_flag])
+    data = json.loads(output.strip())
+    assert isinstance(data, list)
+    for element in data:
+        assert isinstance(element, dict)
+        for key in ('name', 'summary', 'flags'):
+            assert key in element
+        assert isinstance(element['name'], str)
+        assert isinstance(element['summary'], str)
+        assert isinstance(element['flags'], list)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -35,3 +35,8 @@ def test_report_to_dict_with_one_flag(report):
                 'flags': [(0, 10, report_name, "AB", "")]
     }
     assert report.to_dict() == expected
+
+def test_report_to_dict_with_summary(report):
+    report.set_summary(summary)
+    expected = {'name': report_name, 'summary': summary, 'flags': []}
+    assert report.to_dict() == expected

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -26,5 +26,12 @@ def test_report_str_no_flags_with_summary(report):
     assert str(report) == report_name + "\n" + " SUMMARY: " + summary
 
 def test_report_to_dict_no_flags(report):
-    expected = {'name': report_name, 'summary': ""}
+    expected = {'name': report_name, 'summary': "", 'flags': []}
+    assert report.to_dict() == expected
+
+def test_report_to_dict_with_one_flag(report):
+    report.add_flag(flag)
+    expected = {'name': report_name, 'summary': "",
+                'flags': [(0, 10, report_name, "AB", "")]
+    }
     assert report.to_dict() == expected

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -24,3 +24,7 @@ def test_report_str_with_one_flag(report):
 def test_report_str_no_flags_with_summary(report):
     report.set_summary(summary)
     assert str(report) == report_name + "\n" + " SUMMARY: " + summary
+
+def test_report_to_dict_no_flags(report):
+    expected = {'name': report_name, 'summary': ""}
+    assert report.to_dict() == expected

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -4,7 +4,7 @@ from pytest import fixture
 
 report_name = "Text Analyzer"
 summary = "[summary]"
-flag = Flag(0, 10, Issue(report_name, "A" "B"))
+flag = Flag(0, 10, Issue(report_name, "A", "B"))
 
 
 @fixture
@@ -17,7 +17,7 @@ def test_report_str_no_flags(report):
 
 def test_report_str_with_one_flag(report):
     report.add_flag(flag)
-    expected = (report_name + "\n [0-10]: " + report_name + ": AB" + "\n" +
+    expected = (report_name + "\n [0-10]: " + report_name + ": A (B)" + "\n" +
                 " SUMMARY: " + "[None available]")
     assert str(report) == expected
 
@@ -32,7 +32,7 @@ def test_report_to_dict_no_flags(report):
 def test_report_to_dict_with_one_flag(report):
     report.add_flag(flag)
     expected = {'name': report_name, 'summary': "",
-                'flags': [(0, 10, report_name, "AB", "")]
+                'flags': [(0, 10, report_name, "A", "B")]
     }
     assert report.to_dict() == expected
 


### PR DESCRIPTION
With the Report class, the next step seemed to be to add a `to_dict` method. This, in turn, allows the main script to output in JSON format, which should make it much easier to interface with front-end code :)

All features have tests; some tests from before were modified to simplify.