### PR TITLE
Tutorial update and detector method rename

### DIFF
--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -143,9 +143,9 @@ class Detector:
         pass
 
     @abstractmethod
-    def get_flags(self, doc: 'Document'):
+    def get_report(self, doc):
         """
-        Returns a list of flags for a document.
+        Returns a Report for a document.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This fixes some breakage from the recent `get_report` changes.

I also removed the type annotation for `doc`, since if we're sticking with python-2 then this is unsupported.

I've not tested the tutorial, but the changes should be minimal.